### PR TITLE
Update workflow-vllm.yaml

### DIFF
--- a/workflow-vllm.yaml
+++ b/workflow-vllm.yaml
@@ -144,7 +144,6 @@ jobs:
   create_session:
     needs:
       - prepare_job_directory
-      - slurm_job
     ssh:
       remoteHost: ${{ inputs.resource.ip }}
     steps:


### PR DESCRIPTION
The slurm_job  job never stops running so the create_session job is never going to run either. The slurm_job cannot exit because that would trigger the cleanup step to cancel the SLURM job and remove the containers. I have removed the commented out line
#jobid=${{ needs.slurm_job.outputs.jobid }}
as slurm_job cannot be in the needs list. I think this is what probably led to the confusion.