### PR TITLE
Fix git lfs checkout: use positional glob patterns instead of --include

### DIFF
--- a/workflow.yaml
+++ b/workflow.yaml
@@ -504,7 +504,7 @@ jobs:
               ((attempt++))
             done
             echo "Checking out LFS files..."
-            git lfs checkout --include="*.safetensors"
+            git lfs checkout "*.safetensors"
 
             # Fallback: if model only ships bin weights, re-include and fetch those
             if ! ls *.safetensors 1>/dev/null 2>&1; then
@@ -512,7 +512,7 @@ jobs:
               git sparse-checkout set '/*'
               git checkout
               git lfs fetch --include="*.bin"
-              git lfs checkout --include="*.bin"
+              git lfs checkout "*.bin"
             fi
 
             cd "$RUNDIR"

--- a/yamls/hsp.yaml
+++ b/yamls/hsp.yaml
@@ -526,7 +526,7 @@ jobs:
               ((attempt++))
             done
             echo "Checking out LFS files..."
-            git lfs checkout --include="*.safetensors"
+            git lfs checkout "*.safetensors"
 
             # Fallback: if model only ships bin weights, re-include and fetch those
             if ! ls *.safetensors 1>/dev/null 2>&1; then
@@ -534,7 +534,7 @@ jobs:
               git sparse-checkout set '/*'
               git checkout
               git lfs fetch --include="*.bin"
-              git lfs checkout --include="*.bin"
+              git lfs checkout "*.bin"
             fi
 
             cd "$RUNDIR"

--- a/yamls/noaa.yaml
+++ b/yamls/noaa.yaml
@@ -424,7 +424,7 @@ jobs:
               ((attempt++))
             done
             echo "Checking out LFS files..."
-            git lfs checkout --include="*.safetensors"
+            git lfs checkout "*.safetensors"
 
             # Fallback: if model only ships bin weights, re-include and fetch those
             if ! ls *.safetensors 1>/dev/null 2>&1; then
@@ -432,7 +432,7 @@ jobs:
               git sparse-checkout set '/*'
               git checkout
               git lfs fetch --include="*.bin"
-              git lfs checkout --include="*.bin"
+              git lfs checkout "*.bin"
             fi
 
             cd "$RUNDIR"


### PR DESCRIPTION
## Summary
- `git lfs checkout` does not support `--include` (that flag only exists on `git lfs fetch`/`pull`), causing model downloads to fail with `Error: unknown flag: --include`.
- Replace `git lfs checkout --include="*.safetensors"` / `--include="*.bin"` with positional glob patterns (`git lfs checkout "*.safetensors"`) in `workflow.yaml`, `yamls/noaa.yaml`, and `yamls/hsp.yaml`.

## Testing
- Reproduced the failure output from a main-branch run; `git lfs checkout [<glob-pattern>...]` usage confirms positional patterns are the supported form.