### PR TITLE
Auto-install apptainer when missing in Verify Singularity step

### DIFF
--- a/workflow.yaml
+++ b/workflow.yaml
@@ -154,7 +154,50 @@ jobs:
         early-cancel: any-job-failed
         run: |
           set -x
-          command -v singularity >/dev/null 2>&1 || command -v apptainer >/dev/null 2>&1 || { echo "ERROR: singularity/apptainer not found"; exit 1; }
+          has_runtime() { command -v singularity >/dev/null 2>&1 || command -v apptainer >/dev/null 2>&1; }
+
+          # Try environment modules first (HPC clusters)
+          has_runtime || module load singularity 2>/dev/null || module load apptainer 2>/dev/null || true
+
+          # Install apptainer if still missing and passwordless sudo is available
+          if ! has_runtime; then
+            echo "Singularity/Apptainer not found, attempting install..."
+            if ! sudo -n true 2>/dev/null; then
+              echo "ERROR: singularity/apptainer not found and passwordless sudo is unavailable to install it"
+              echo "Install apptainer manually or make it available via 'module load'"
+              exit 1
+            fi
+            if command -v dnf >/dev/null 2>&1; then
+              sudo dnf install -y epel-release || true
+              sudo dnf install -y apptainer
+            elif command -v yum >/dev/null 2>&1; then
+              sudo yum install -y epel-release || true
+              sudo yum install -y apptainer
+            elif command -v apt-get >/dev/null 2>&1; then
+              export DEBIAN_FRONTEND=noninteractive
+              sudo apt-get update -y
+              if ! sudo apt-get install -y apptainer; then
+                # Not in distro repos: pull the upstream release .deb
+                command -v curl >/dev/null 2>&1 || sudo apt-get install -y curl
+                VER=$(curl -fsSL https://api.github.com/repos/apptainer/apptainer/releases/latest | sed -n 's/.*"tag_name": *"v\([^"]*\)".*/\1/p')
+                VER=${VER:-1.4.1}
+                ARCH=$(dpkg --print-architecture)
+                curl -fsSL -o /tmp/apptainer.deb "https://github.com/apptainer/apptainer/releases/download/v${VER}/apptainer_${VER}_${ARCH}.deb"
+                sudo apt-get install -y /tmp/apptainer.deb
+                rm -f /tmp/apptainer.deb
+              fi
+            else
+              echo "ERROR: no supported package manager (dnf/yum/apt-get) found to install apptainer"
+              exit 1
+            fi
+          fi
+
+          # start_service.sh invokes 'singularity' directly; ensure the alias exists
+          if ! command -v singularity >/dev/null 2>&1 && command -v apptainer >/dev/null 2>&1; then
+            sudo -n ln -sf "$(command -v apptainer)" /usr/local/bin/singularity 2>/dev/null || true
+          fi
+
+          has_runtime || { echo "ERROR: singularity/apptainer not found"; exit 1; }
           singularity --version || apptainer --version
           echo "Singularity/Apptainer ready"
       


### PR DESCRIPTION
## Summary
- The `prepare_containers` job failed hard with `ERROR: singularity/apptainer not found` on nodes without a container runtime.
- The `Verify Singularity Available` step now: checks PATH → tries `module load singularity`/`apptainer` (HPC) → installs apptainer when passwordless sudo is available (dnf/yum via EPEL, or apt-get with a fallback to the upstream release .deb), and errors with clear guidance otherwise.
- Ensures a `singularity` alias exists after install since `start_service.sh` and the container build step invoke `singularity` directly.

Site-specific yamls (`noaa.yaml`, `hsp.yaml`, `emed.yaml`) are unchanged — shared clusters keep the module-load + descriptive-error behavior.

## Testing
- YAML parses cleanly and the step's shell block passes `bash -n`.