### PR TITLE
Harden apptainer .deb fallback: avoid GitHub API, add curl timeouts

### DIFF
--- a/workflow.yaml
+++ b/workflow.yaml
@@ -177,12 +177,18 @@ jobs:
               export DEBIAN_FRONTEND=noninteractive
               sudo apt-get update -y
               if ! sudo apt-get install -y apptainer; then
-                # Not in distro repos: pull the upstream release .deb
+                # Not in distro repos: pull the upstream release .deb.
+                # Resolve the tag from the releases/latest redirect instead of
+                # api.github.com, which is rate-limited from shared cloud IPs.
                 command -v curl >/dev/null 2>&1 || sudo apt-get install -y curl
-                VER=$(curl -fsSL https://api.github.com/repos/apptainer/apptainer/releases/latest | sed -n 's/.*"tag_name": *"v\([^"]*\)".*/\1/p')
-                VER=${VER:-1.4.1}
                 ARCH=$(dpkg --print-architecture)
-                curl -fsSL -o /tmp/apptainer.deb "https://github.com/apptainer/apptainer/releases/download/v${VER}/apptainer_${VER}_${ARCH}.deb"
+                if [[ "$ARCH" != "amd64" ]]; then
+                  echo "ERROR: upstream apptainer .deb releases are amd64-only (this node is $ARCH); install apptainer manually"
+                  exit 1
+                fi
+                VER=$(curl -fsSL --connect-timeout 15 --max-time 60 -o /dev/null -w '%{url_effective}' https://github.com/apptainer/apptainer/releases/latest | sed -n 's|.*/tag/v||p')
+                VER=${VER:-1.5.2}
+                curl -fsSL --connect-timeout 15 --max-time 600 -o /tmp/apptainer.deb "https://github.com/apptainer/apptainer/releases/download/v${VER}/apptainer_${VER}_${ARCH}.deb"
                 sudo apt-get install -y /tmp/apptainer.deb
                 rm -f /tmp/apptainer.deb
               fi


### PR DESCRIPTION
## Summary
- A run stalled at the apptainer version lookup: `curl https://api.github.com/.../releases/latest` can hang without timeouts and is rate-limited (60 req/hr) from shared cloud NAT IPs, returning empty on 403.
- Resolve the latest tag from the `github.com/.../releases/latest` redirect instead — same host as the .deb download, no API rate limits, and already proven reachable by the repo clone in setup.
- Add `--connect-timeout`/`--max-time` to both curl calls so the step can never hang.
- Bump the pinned fallback version 1.4.1 → 1.5.2 (current latest).
- Fail fast with a clear error on non-amd64 nodes: upstream releases only ship amd64 .debs.

## Testing
- Verified the redirect resolves to `v1.5.2` and the constructed .deb URL returns HTTP 200.
- YAML parses; step shell block passes `bash -n`.