### PR TITLE
Fetch tokenizer LFS assets in model clone; fail fast on incomplete model dirs

### DIFF
--- a/start_service.sh
+++ b/start_service.sh
@@ -249,6 +249,24 @@ elif [ "$RUNMODE" == "singularity" ]; then
         exit 1
     fi
 
+    # Fail fast on incomplete model directories instead of letting vLLM
+    # crash with an opaque tokenizer traceback
+    if [[ ! -s "$MODEL_PATH/config.json" ]]; then
+        echo "$(date) ERROR: config.json is missing from $MODEL_PATH; the model directory is incomplete"
+        exit 1
+    fi
+    if [[ ! -s "$MODEL_PATH/tokenizer.json" && ! -s "$MODEL_PATH/tokenizer.model" && ! -s "$MODEL_PATH/vocab.json" && ! -s "$MODEL_PATH/tekken.json" ]]; then
+        echo "$(date) ERROR: No tokenizer file (tokenizer.json/tokenizer.model/vocab.json) found in $MODEL_PATH"
+        echo "$(date) Download the tokenizer assets from the model's HuggingFace repo into $MODEL_PATH"
+        exit 1
+    fi
+    for f in config.json tokenizer.json tokenizer.model vocab.json tekken.json; do
+        if [[ -f "$MODEL_PATH/$f" ]] && head -c 60 "$MODEL_PATH/$f" | grep -q "git-lfs.github.com/spec"; then
+            echo "$(date) ERROR: $MODEL_PATH/$f is a git-lfs pointer stub, not the real file; re-download it with git lfs"
+            exit 1
+        fi
+    done
+
     # Disable weight download if cache exists
     if [ -d "cache/huggingface" ]; then
         sed -i 's/#export TRANSFORMERS_OFFLINE=1/export TRANSFORMERS_OFFLINE=1/' env.sh

--- a/workflow.yaml
+++ b/workflow.yaml
@@ -562,9 +562,11 @@ jobs:
             GIT_LFS_SKIP_SMUDGE=1 git clone --depth 1 --no-checkout "$REPO_URL" "$TARGET_DIR"
             cd "$TARGET_DIR"
 
-            # Sparse checkout: exclude bin/gguf/onnx/pth to only get safetensors weights
+            # Sparse checkout: exclude alternate weight formats and duplicate
+            # checkpoint dirs (original/, metal/), keeping safetensors weights
+            # plus tokenizer/config assets
             git sparse-checkout init --no-cone
-            git sparse-checkout set '/*' '!*.bin' '!*.gguf' '!*.onnx' '!consolidated*.pth'
+            git sparse-checkout set '/*' '!*.bin' '!*.gguf' '!*.onnx' '!consolidated*.pth' '!/original' '!/metal'
             git checkout
 
             # Configure LFS for reliability with large models
@@ -573,12 +575,13 @@ jobs:
             git config lfs.transfer.maxretries 10
             git config lfs.transfer.maxretrydelay 30
 
-            # Fetch only safetensors LFS objects with progress and retry logic
+            # Fetch all needed LFS objects (weights + tokenizer assets like
+            # gpt-oss's LFS-tracked tokenizer.json) with retry logic
             attempt=1
             max_attempts=3
             while true; do
               echo "LFS fetch attempt ${attempt}/${max_attempts}..."
-              if git lfs fetch --include="*.safetensors"; then
+              if git lfs fetch --exclude="*.bin,*.gguf,*.onnx,consolidated*.pth,original/*,metal/*"; then
                 break
               fi
               if [[ $attempt -ge $max_attempts ]]; then
@@ -589,7 +592,7 @@ jobs:
               ((attempt++))
             done
             echo "Checking out LFS files..."
-            git lfs checkout "*.safetensors"
+            git lfs checkout
 
             # Fallback: if model only ships bin weights, re-include and fetch those
             if ! ls *.safetensors 1>/dev/null 2>&1; then
@@ -615,6 +618,13 @@ jobs:
               done
             fi
             
+            # Verify tokenizer assets are real files, not LFS pointers
+            for tf in tokenizer.json tokenizer.model vocab.json tekken.json; do
+              if [[ -f "$TARGET_DIR/$tf" ]] && head -c 60 "$TARGET_DIR/$tf" | grep -q "git-lfs.github.com/spec"; then
+                echo "ERROR: $TARGET_DIR/$tf is a git-lfs pointer, not the real file"; exit 1
+              fi
+            done
+
             [[ ! -f "$TARGET_DIR/config.json" ]] && { echo "ERROR: Model clone incomplete - missing config.json"; exit 1; }
           fi
           

--- a/yamls/hsp.yaml
+++ b/yamls/hsp.yaml
@@ -499,9 +499,11 @@ jobs:
             GIT_LFS_SKIP_SMUDGE=1 git clone --depth 1 --no-checkout "$REPO_URL" "$TARGET_DIR"
             cd "$TARGET_DIR"
 
-            # Sparse checkout: exclude bin/gguf/onnx/pth to only get safetensors weights
+            # Sparse checkout: exclude alternate weight formats and duplicate
+            # checkpoint dirs (original/, metal/), keeping safetensors weights
+            # plus tokenizer/config assets
             git sparse-checkout init --no-cone
-            git sparse-checkout set '/*' '!*.bin' '!*.gguf' '!*.onnx' '!consolidated*.pth'
+            git sparse-checkout set '/*' '!*.bin' '!*.gguf' '!*.onnx' '!consolidated*.pth' '!/original' '!/metal'
             git checkout
 
             # Configure LFS for reliability with large models
@@ -510,12 +512,13 @@ jobs:
             git config lfs.transfer.maxretries 10
             git config lfs.transfer.maxretrydelay 30
 
-            # Fetch only safetensors LFS objects with progress and retry logic
+            # Fetch all needed LFS objects (weights + tokenizer assets like
+            # gpt-oss's LFS-tracked tokenizer.json) with retry logic
             attempt=1
             max_attempts=3
             while true; do
               echo "::notice::LFS fetch attempt ${attempt}/${max_attempts} — downloading model weights (large files, this may take a while)..."
-              if git lfs fetch --include="*.safetensors"; then
+              if git lfs fetch --exclude="*.bin,*.gguf,*.onnx,consolidated*.pth,original/*,metal/*"; then
                 break
               fi
               if [[ $attempt -ge $max_attempts ]]; then
@@ -526,7 +529,7 @@ jobs:
               ((attempt++))
             done
             echo "Checking out LFS files..."
-            git lfs checkout "*.safetensors"
+            git lfs checkout
 
             # Fallback: if model only ships bin weights, re-include and fetch those
             if ! ls *.safetensors 1>/dev/null 2>&1; then
@@ -551,6 +554,13 @@ jobs:
                 break  # Just check the first one
               done
             fi
+
+            # Verify tokenizer assets are real files, not LFS pointers
+            for tf in tokenizer.json tokenizer.model vocab.json tekken.json; do
+              if [[ -f "$TARGET_DIR/$tf" ]] && head -c 60 "$TARGET_DIR/$tf" | grep -q "git-lfs.github.com/spec"; then
+                echo "::error title=Incomplete Download::$TARGET_DIR/$tf is a git-lfs pointer rather than the real file. The LFS fetch may have failed."; exit 1
+              fi
+            done
 
             [[ ! -f "$TARGET_DIR/config.json" ]] && { echo "::error title=Incomplete Clone::Model clone is incomplete — config.json is missing from $TARGET_DIR. Try re-running the workflow."; exit 1; }
 

--- a/yamls/noaa.yaml
+++ b/yamls/noaa.yaml
@@ -397,9 +397,11 @@ jobs:
             GIT_LFS_SKIP_SMUDGE=1 git clone --depth 1 --no-checkout "$REPO_URL" "$TARGET_DIR"
             cd "$TARGET_DIR"
 
-            # Sparse checkout: exclude bin/gguf/onnx/pth to only get safetensors weights
+            # Sparse checkout: exclude alternate weight formats and duplicate
+            # checkpoint dirs (original/, metal/), keeping safetensors weights
+            # plus tokenizer/config assets
             git sparse-checkout init --no-cone
-            git sparse-checkout set '/*' '!*.bin' '!*.gguf' '!*.onnx' '!consolidated*.pth'
+            git sparse-checkout set '/*' '!*.bin' '!*.gguf' '!*.onnx' '!consolidated*.pth' '!/original' '!/metal'
             git checkout
 
             # Configure LFS for reliability with large models
@@ -408,12 +410,13 @@ jobs:
             git config lfs.transfer.maxretries 10
             git config lfs.transfer.maxretrydelay 30
 
-            # Fetch only safetensors LFS objects with progress and retry logic
+            # Fetch all needed LFS objects (weights + tokenizer assets like
+            # gpt-oss's LFS-tracked tokenizer.json) with retry logic
             attempt=1
             max_attempts=3
             while true; do
               echo "::notice::LFS fetch attempt ${attempt}/${max_attempts} — downloading model weights (large files, this may take a while)..."
-              if git lfs fetch --include="*.safetensors"; then
+              if git lfs fetch --exclude="*.bin,*.gguf,*.onnx,consolidated*.pth,original/*,metal/*"; then
                 break
               fi
               if [[ $attempt -ge $max_attempts ]]; then
@@ -424,7 +427,7 @@ jobs:
               ((attempt++))
             done
             echo "Checking out LFS files..."
-            git lfs checkout "*.safetensors"
+            git lfs checkout
 
             # Fallback: if model only ships bin weights, re-include and fetch those
             if ! ls *.safetensors 1>/dev/null 2>&1; then
@@ -450,6 +453,13 @@ jobs:
               done
             fi
             
+            # Verify tokenizer assets are real files, not LFS pointers
+            for tf in tokenizer.json tokenizer.model vocab.json tekken.json; do
+              if [[ -f "$TARGET_DIR/$tf" ]] && head -c 60 "$TARGET_DIR/$tf" | grep -q "git-lfs.github.com/spec"; then
+                echo "::error title=Incomplete Download::$TARGET_DIR/$tf is a git-lfs pointer rather than the real file. The LFS fetch may have failed."; exit 1
+              fi
+            done
+
             [[ ! -f "$TARGET_DIR/config.json" ]] && { echo "::error title=Incomplete Clone::Model clone is incomplete — config.json is missing from $TARGET_DIR. Try re-running the workflow."; exit 1; }
           fi
 


### PR DESCRIPTION
## Summary
- vLLM crashed with `AttributeError: 'NoneType' object has no attribute 'endswith'` in tokenizer conversion when serving gpt-oss-120b. Root cause: gpt-oss ships `tokenizer.json` as a 27.9 MB **LFS-tracked** file, and the model clone's `git lfs fetch --include="*.safetensors"` never materialized it.
- The HF-clone steps (workflow.yaml, hsp.yaml, noaa.yaml) now fetch with `--exclude="*.bin,*.gguf,*.onnx,consolidated*.pth,original/*,metal/*"` and do a full `git lfs checkout`, so tokenizer/config LFS assets come down with the weights.
- Sparse checkout additionally excludes `original/` and `metal/` — the old `*.safetensors` include was silently downloading gpt-oss-120b's duplicate original-format checkpoint (~65 GB saved per download).
- Post-download verification now also rejects tokenizer files that are still LFS pointer stubs.
- `start_service.sh` fails fast with a one-line error when the model directory is missing `config.json`, has no tokenizer file (`tokenizer.json`/`tokenizer.model`/`vocab.json`/`tekken.json`), or has LFS pointer stubs — instead of an opaque vLLM traceback.

## Testing
- Confirmed via the HF API that `openai/gpt-oss-120b` tracks `tokenizer.json` (27.9 MB) in LFS alongside 14 safetensors shards plus `original/` and `metal/` dirs.
- All run blocks in the three yamls pass `bash -n` (templates stubbed); `start_service.sh` passes `bash -n`.