### PR TITLE
Prompt for session name at launch

### DIFF
--- a/workflow.yaml
+++ b/workflow.yaml
@@ -34,6 +34,8 @@ sessions:
   session:
     redirect: false
     openAI: true
+    prompt-for-name:
+      default: rag-vllm
 
 # ==============================================================================
 # JOB DEFINITIONS


### PR DESCRIPTION
## Summary
- Adds `prompt-for-name` (default `rag-vllm`) to the session definition in `workflow.yaml`, so launches ask for a session name instead of using the generic default — easier to identify in the session list when multiple deployments are running.
- Existing session settings (`redirect: false`, `openAI: true`) unchanged. Site-specific yamls (noaa/hsp/emed) left as-is.

## Testing
- YAML parses; sessions block renders as expected.