### PR TITLE
Bind user-facing service to the session runner's pre-allocated port

### DIFF
--- a/start_service.sh
+++ b/start_service.sh
@@ -200,20 +200,23 @@ elif [ "$RUNMODE" == "singularity" ]; then
     cp singularity/env.sh.example env.sh
     cp singularity/Singularity.* ./
 
-    # Allocate ports for all services
-    VLLM_SERVER_PORT=$(pw agent open-port)
-    RAG_PORT=$(pw agent open-port)
-    CHROMA_PORT=$(pw agent open-port)
-    PROXY_PORT=$(pw agent open-port)
-
-    # Set SESSION_PORT based on deployment type
+    # Allocate service ports. The session runner pre-allocates ${service_port},
+    # writes it to SESSION_PORT, and points the session and its readiness poll
+    # at it before this script runs, so the user-facing service must bind to it
+    # rather than allocating its own port (matches the docker branch behavior).
     # - vLLM only: users connect directly to vLLM
     # - all (RAG): users connect to RAG proxy which forwards to vLLM
     if [ "$RUNTYPE" == "all" ]; then
-        echo "${PROXY_PORT}" > SESSION_PORT 
+        PROXY_PORT=${service_port:-$(pw agent open-port)}
+        VLLM_SERVER_PORT=$(pw agent open-port)
+        echo "${PROXY_PORT}" > SESSION_PORT
     else
-        echo "${VLLM_SERVER_PORT}" > SESSION_PORT 
+        VLLM_SERVER_PORT=${service_port:-$(pw agent open-port)}
+        PROXY_PORT=$(pw agent open-port)
+        echo "${VLLM_SERVER_PORT}" > SESSION_PORT
     fi
+    RAG_PORT=$(pw agent open-port)
+    CHROMA_PORT=$(pw agent open-port)
 
     sed -i "s/^export VLLM_SERVER_PORT=.*/export VLLM_SERVER_PORT=${VLLM_SERVER_PORT}/" env.sh
     sed -i "s/^export RAG_PORT=.*/export RAG_PORT=${RAG_PORT}/" env.sh


### PR DESCRIPTION
## Summary
- Deployments hung at `Attempt N: server not yet ready` even though vLLM was fully up. Root cause: the `interactive_session` runner pre-allocates `${service_port}`, writes it to `SESSION_PORT`, and points both the session and the readiness poll at it **before** `start_service.sh` runs. The singularity branch ignored `${service_port}`, allocated its own ports, and overwrote `SESSION_PORT` after the runner had already read it — so vLLM served on a port nothing polls (observed: session polling 41473 while vLLM listened on 37213).
- The singularity branch now binds the user-facing service (vLLM directly for `runtype=vllm`, the RAG proxy for `runtype=all`) to `${service_port}` when provided — the same contract the docker branch already follows — falling back to `pw agent open-port` for manual runs outside the session runner. Internal ports (RAG, Chroma, and the non-facing one of vLLM/proxy) are still allocated dynamically.

## Testing
- `bash -n` passes. Verified the runner contract by reading `interactive_session` `workflow/session_runner/v1.4/general.yaml`: the generated wrapper writes `${service_port}` to `SESSION_PORT` and touches `job.started` before appending this script, and `create_session`/`update-session` consume that value.