### PR TITLE
Write localhost to HOSTNAME for unscheduled runs

### DIFF
--- a/start_service.sh
+++ b/start_service.sh
@@ -3,7 +3,15 @@ set -x
 # Note: job.started and HOSTNAME markers are injected by script_submitter v4.0
 # when inject_markers=true (default)
 touch job.started
-hostname | cut -d'.' -f1 > HOSTNAME
+# The session tunnel targets the contents of HOSTNAME. Under a scheduler the
+# service runs on a compute node, so its hostname is needed; for direct
+# execution the agent reaches the service on localhost (cloud VM hostnames
+# are not usable as tunnel targets).
+if [[ -n "${SLURM_JOB_ID:-}" || -n "${PBS_JOBID:-}" ]]; then
+    hostname | cut -d'.' -f1 > HOSTNAME
+else
+    echo localhost > HOSTNAME
+fi
 
 source .run.env > /dev/null 2>&1
 #rm .run.env > /dev/null 2>&1


### PR DESCRIPTION
## Summary
- The session reached Ready but the tunnel session errored: it was registered against the cloud VM hostname (`7af9cf25-...:37327`) instead of `localhost`. Working sessions of the same workflow target `localhost`.
- Root cause: the session_runner substitutes `localhost` only when `inputs.cluster.scheduler` renders exactly `"false"`, but our `submit_to_scheduler` input is hidden on non-scheduler resources and rendered as an empty string (`+ '[' '' = false ']'` in the Get Hostname step log), so it fell through to `cat HOSTNAME`.
- `start_service.sh` now decides at runtime: under SLURM/PBS (`SLURM_JOB_ID`/`PBS_JOBID` set) it writes the compute-node hostname as before; for direct execution it writes `localhost`, which is what the tunnel needs.

## Testing
- `bash -n` passes. Verified via `pw` CLI on run mp-vllmrag-00011: session `pwsupport.mmec/vllm` is in error state targeting the VM hostname while a known-good session of this workflow targets localhost; a manual localhost tunnel to the same port validates connectivity (see PR discussion).