### PR TITLE
Install apptainer from the official PPA on Ubuntu

### DIFF
--- a/workflow.yaml
+++ b/workflow.yaml
@@ -180,20 +180,31 @@ jobs:
               export DEBIAN_FRONTEND=noninteractive
               sudo apt-get update -y
               if ! sudo apt-get install -y apptainer; then
-                # Not in distro repos: pull the upstream release .deb.
-                # Resolve the tag from the releases/latest redirect instead of
-                # api.github.com, which is rate-limited from shared cloud IPs.
-                command -v curl >/dev/null 2>&1 || sudo apt-get install -y curl
-                ARCH=$(dpkg --print-architecture)
-                if [[ "$ARCH" != "amd64" ]]; then
-                  echo "ERROR: upstream apptainer .deb releases are amd64-only (this node is $ARCH); install apptainer manually"
-                  exit 1
+                # Not in the distro repos. On Ubuntu use the official apptainer
+                # PPA (per-release builds, all architectures); otherwise fall
+                # back to the upstream release .deb from GitHub.
+                . /etc/os-release 2>/dev/null || true
+                if [[ "${ID:-}" == "ubuntu" ]]; then
+                  sudo apt-get install -y software-properties-common
+                  sudo add-apt-repository -y ppa:apptainer/ppa
+                  sudo apt-get update -y
+                  sudo apt-get install -y apptainer
                 fi
-                VER=$(curl -fsSL --connect-timeout 15 --max-time 60 -o /dev/null -w '%{url_effective}' https://github.com/apptainer/apptainer/releases/latest | sed -n 's|.*/tag/v||p')
-                VER=${VER:-1.5.2}
-                curl -fsSL --connect-timeout 15 --max-time 600 -o /tmp/apptainer.deb "https://github.com/apptainer/apptainer/releases/download/v${VER}/apptainer_${VER}_${ARCH}.deb"
-                sudo apt-get install -y /tmp/apptainer.deb
-                rm -f /tmp/apptainer.deb
+                if ! command -v apptainer >/dev/null 2>&1; then
+                  # Resolve the tag from the releases/latest redirect instead of
+                  # api.github.com, which is rate-limited from shared cloud IPs.
+                  command -v curl >/dev/null 2>&1 || sudo apt-get install -y curl
+                  ARCH=$(dpkg --print-architecture)
+                  if [[ "$ARCH" != "amd64" ]]; then
+                    echo "ERROR: upstream apptainer .deb releases are amd64-only (this node is $ARCH); install apptainer manually"
+                    exit 1
+                  fi
+                  VER=$(curl -fsSL --connect-timeout 15 --max-time 60 -o /dev/null -w '%{url_effective}' https://github.com/apptainer/apptainer/releases/latest | sed -n 's|.*/tag/v||p')
+                  VER=${VER:-1.5.2}
+                  curl -fsSL --connect-timeout 15 --max-time 600 -o /tmp/apptainer.deb "https://github.com/apptainer/apptainer/releases/download/v${VER}/apptainer_${VER}_${ARCH}.deb"
+                  sudo apt-get install -y /tmp/apptainer.deb
+                  rm -f /tmp/apptainer.deb
+                fi
               fi
             else
               echo "ERROR: no supported package manager (dnf/yum/apt-get) found to install apptainer"


### PR DESCRIPTION
## Summary
- The apptainer auto-install failed on an Ubuntu node where the upstream GitHub .deb route didn't work. The apt branch now tries, in order: distro repo → **official `ppa:apptainer/ppa`** (Ubuntu only, via `software-properties-common`/`add-apt-repository`) → upstream release .deb (unchanged, still amd64-only last resort).
- The PPA is the apptainer project's recommended Ubuntu install path, ships per-release builds, and covers arm64, which the .deb fallback cannot.

## Testing
- Install sequence verified manually on the affected Ubuntu system (PPA route works). YAML parses; all run blocks pass `bash -n`.